### PR TITLE
Added stream end to the transform stream to determine when execution is done

### DIFF
--- a/gulp-run.js
+++ b/gulp-run.js
@@ -24,7 +24,12 @@ var GulpRunner = module.exports = function run(template, opts) {
 	// A GulpRunner is a Vinyl transform stream that uses the `command` to process input.
 	Transform.call(this, {objectMode:true});
 	this._transform = function _transform(file, enc, callback) {
-		var newfile = command.exec(file, callback);
+		var stream = this,
+		    handleEnd = function(error) {
+		    	stream.push(null);
+		    	callback(error);
+                    },
+		    newfile = command.exec(file, handleEnd);
 		this.push(newfile);
 	};
 


### PR DESCRIPTION
I had a problem that the gulp never knew when this particular stream ended, so here's a solution.

I wanted to fix the tests to instead of call(done) to listen end event and then call done, but for some reason the compare stream also never emits end. I added push(null) to bunch of places but gave up after an hour of fiddling with them. The code is semi hard to read with multiple transform streams.

I'd write the tests so that I would use highland instead of the transform streams. With highland you can use doto to do the actual expects so you won't have to deal with transform streams. I would look into this at some point, but currently I'm too busy. So here's my drive-by PR. :grin: 