### PR TITLE
Added option to use PowerShell instead of cmd.exe on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Represents a command to be run in a subshell.
         - `0`: Do not print anything, ever.
         - `1`: Print the command being run and its stderr.
         - `2`: Print the command, its stderr, and its stdout.
+    - `usePowerShell` *(Boolean)*: *Windows only*. If `true` uses the PowerShell instead of `cmd.exe` for command execution.
 
 ---
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -24,7 +24,8 @@ module.exports = function Command(commandTemplate, opts) {
 		cwd: process.cwd(),
 		env: process.env,
 		silent: false,
-		verbosity: (opts && opts.silent) ? 1 : 2
+		verbosity: (opts && opts.silent) ? 1 : 2,
+		usePowerShell: false
 	});
 
 	// Include node_modules/.bin on the path when we execute the command.
@@ -72,7 +73,11 @@ module.exports = function Command(commandTemplate, opts) {
 		var command = _.template(commandTemplate, {file:stdin});
 		var subshell;
 		if (isWindows) {
-			subshell = childProcess.spawn('cmd.exe', ['/c', command], {env:opts.env, cwd:opts.cwd});
+			if (opts.usePowerShell) {
+				subshell = childProcess.spawn('powershell.exe', ['-NonInteractive', '-NoLogo', '-Command', command], {env:opts.env, cwd:opts.cwd});
+			} else {
+				subshell = childProcess.spawn('cmd.exe', ['/c', command], {env:opts.env, cwd:opts.cwd});
+			}
 		} else {
 			subshell = childProcess.spawn('sh', ['-c', command], {env:opts.env, cwd:opts.cwd});
 		}


### PR DESCRIPTION
I needed the option to run PowerShell commands on Windows instead of using the standard cmd.exe. The change is backwards compatible as it leaves the default to cmd.exe.