### PR TITLE
Fixed #25: Added verbosity level 3 for live subprocess output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Represents a command to be run in a subshell.
         - `0`: Do not print anything, ever.
         - `1`: Print the command being run and its stderr.
         - `2`: Print the command, its stderr, and its stdout.
+        - `3`: Print the command, its stderr, and its stdout progressivly. Not useful if you have concurrent gulp-run instances, as the outputs may get mixed.
     - `usePowerShell` *(Boolean)*: *Windows only*. If `true` uses the PowerShell instead of `cmd.exe` for command execution.
 
 ---

--- a/lib/command.js
+++ b/lib/command.js
@@ -84,24 +84,25 @@ module.exports = function Command(commandTemplate, opts) {
 
 		// Setup the logs. The stdout of the command is only logged if the verbosity is greater
 		// than 2. The stderr is always logged.
+		if(opts.verbosity < 3) {
 		var logStream = new stream.PassThrough();
-		if (opts.verbosity >= 2) {
+			if (opts.verbosity == 2) {
 			subshell.stdout.pipe(logStream);
 		}
 		subshell.stderr.pipe(logStream);
+		}else {
+			logTitle();
+			subshell.stdout.pipe(process.stdout);
+			subshell.stderr.pipe(process.stderr);
+		}
 
 		// Invoke the callback once the command has finished.
 		subshell.once('close', function (code) {
 
 			// Print the logs (i.e. the stdout and stderr). We wait until the subshell has closed
 			// to write all of the logs at once, avoiding race conditions with concurrent commands.
-			if (opts.verbosity >= 1) {
-				var logTitle = util.format(
-					'$ %s %s',
-					gutil.colors.blue(command),
-					(opts.verbosity < 2) ? gutil.colors.grey('# Silenced') : ''
-				);
-				gutil.log(logTitle);
+			if (opts.verbosity >= 1 && opts.verbosity < 3) {
+				logTitle();
 				var logContents = logStream.read();
 				if (logContents !== null) process.stdout.write(logContents);
 			}
@@ -124,6 +125,16 @@ module.exports = function Command(commandTemplate, opts) {
 		// Finally, write the input to the process's stdin.
 		stdin.pipe(subshell.stdin);
 		return stdout;
+
+		function logTitle(){
+			var logTitle = util.format(
+				'$ %s %s',
+				gutil.colors.blue(command),
+				(opts.verbosity < 2) ? gutil.colors.grey('# Silenced') : ''
+			);
+			gutil.log(logTitle);
+		}
+
 	};
 
 

--- a/spec/gulp-run.js
+++ b/spec/gulp-run.js
@@ -69,6 +69,12 @@ describe('gulp-run', function () {
 				expect(output).to.match(/\[.*\] \$ echo "testing verbosity:2"\s*\ntesting verbosity:2/);
 				s.done();
 			});
+
+		(new run.Command('echo "testing verbosity:3"', {verbosity:3}))
+			.exec(function () {
+				var output = colors.stripColor(writtenOutput);
+				expect(output).to.match(/\[.*\] \$ echo "testing verbosity:3"\s*\ntesting verbosity:3/);
+			});
 	});
 
 


### PR DESCRIPTION
In a project we start different non-terminating processes during development with `gulp run`,
like a node webserver for development or a spring rest api.

Also live output for long taking processes like `npm install` or `mvn install` or `bower install` is somewhat appreciated.
